### PR TITLE
feat: add Bun.Image favicon option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.15.0
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -21,6 +24,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.15.0
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm dlx pkg-pr-new publish --pnpm .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          node-version: 22.15.0
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          standalone: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
@@ -24,9 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          node-version: 22.15.0
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          standalone: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm dlx pkg-pr-new publish --pnpm .

--- a/.github/workflows/page.yaml
+++ b/.github/workflows/page.yaml
@@ -11,10 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          node-version: 22.15.0
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          standalone: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
         working-directory: example

--- a/.github/workflows/page.yaml
+++ b/.github/workflows/page.yaml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.15.0
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.15.0
+
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - run: pnpm dlx changelogithub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          node-version: 22.15.0
-
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          standalone: true
 
       - run: pnpm dlx changelogithub
         env:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ While the example above is Svelte-specific, you can use this plugin with any fra
 The plugin accepts the following options:
 
 - `imgSrc` (required): Path to the source image for generating favicons
-- `faviconAssetsDest` (optional): Output path for favicon images and manifest (default: `${assetsDir}/favicons`)
+- `path` (required): Public path for generated favicon assets. It must start with `/`
+- `cache` (optional): Whether to cache generated favicons (default: `false` in production, `true` in development)
+- `useBunImage` (optional): Use `Bun.Image` via `Bun.module` instead of loading `sharp` from `favicons`. This requires running the Vite build with Bun and a Bun version that includes `Bun.Image`
 - Other options from the `Favicons` package
 
 The additional options are based on the `Favicons` library. For a full list of options and their descriptions, please refer to the [Favicons package documentation](https://www.npmjs.com/package/favicons).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The plugin accepts the following options:
 - `imgSrc` (required): Path to the source image for generating favicons
 - `path` (required): Public path for generated favicon assets. It must start with `/`
 - `cache` (optional): Whether to cache generated favicons (default: `false` in production, `true` in development)
-- `useBunImage` (optional): Use `Bun.Image` via `Bun.module` instead of loading `sharp` from `favicons`. Bun imports enable this by default. You can also import from `vite-plugin-favicons/bun` to opt in explicitly
+- `useBunImage` (optional): Use `Bun.Image` via `Bun.module` for supported resize operations, falling back to `sharp` for image operations that Bun does not expose. Bun imports enable this by default. You can also import from `vite-plugin-favicons/bun` to opt in explicitly
 - Other options from the `Favicons` package
 
 The additional options are based on the `Favicons` library. For a full list of options and their descriptions, please refer to the [Favicons package documentation](https://www.npmjs.com/package/favicons).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The plugin accepts the following options:
 - `imgSrc` (required): Path to the source image for generating favicons
 - `path` (required): Public path for generated favicon assets. It must start with `/`
 - `cache` (optional): Whether to cache generated favicons (default: `false` in production, `true` in development)
-- `useBunImage` (optional): Use `Bun.Image` via `Bun.module` instead of loading `sharp` from `favicons`. This requires running the Vite build with Bun and a Bun version that includes `Bun.Image`
+- `useBunImage` (optional): Use `Bun.Image` via `Bun.module` instead of loading `sharp` from `favicons`. Bun imports enable this by default. You can also import from `vite-plugin-favicons/bun` to opt in explicitly
 - Other options from the `Favicons` package
 
 The additional options are based on the `Favicons` library. For a full list of options and their descriptions, please refer to the [Favicons package documentation](https://www.npmjs.com/package/favicons).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
 	"exports": {
 		".": {
 			"types": "./types/index.d.ts",
+			"bun": "./src/index.bun.js",
 			"import": "./src/index.js"
+		},
+		"./bun": {
+			"types": "./types/index.d.ts",
+			"import": "./src/index.bun.js"
 		}
 	},
 	"types": "./types/index.d.ts",
@@ -17,6 +22,20 @@
 		"src",
 		"types"
 	],
+	"engines": {
+		"runtime": [
+			{
+				"name": "node",
+				"version": "^22.15.0",
+				"onFail": "download"
+			},
+			{
+				"name": "bun",
+				"version": "^1.3.14",
+				"onFail": "download"
+			}
+		]
+	},
 	"scripts": {
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint --cache .",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vite-plugin-favicons",
 	"type": "module",
 	"version": "0.1.7",
-	"packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+	"packageManager": "pnpm@11.1.2+sha512-415e872cb975731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f797597e1be961a1062223a1967b16569499",
 	"author": "ryoppippi",
 	"exports": {
 		".": {
@@ -28,19 +28,21 @@
 		"release:npm": "pnpm publish"
 	},
 	"peerDependencies": {
-		"vite": "^5.0.0 | ^6.0.0 | ^7.0.0"
+		"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
 	},
 	"dependencies": {
 		"consola": "^3.4.2",
 		"favicons": "^7.2.0",
 		"fs-extra": "^11.3.0",
 		"pathe": "^2.0.3",
+		"pngjs": "^7.0.0",
 		"std-env": "^3.9.0"
 	},
 	"devDependencies": {
 		"@antfu/ni": "^25.0.0",
 		"@ryoppippi/eslint-config": "^0.3.7",
 		"@types/fs-extra": "^11.0.4",
+		"@types/pngjs": "^6.0.5",
 		"bumpp": "^10.2.0",
 		"dts-buddy": "^0.6.2",
 		"eslint": "^9.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,22 +29,28 @@ importers:
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       std-env:
         specifier: ^3.9.0
         version: 3.9.0
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+        version: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
     devDependencies:
       '@antfu/ni':
         specifier: ^25.0.0
         version: 25.0.0
       '@ryoppippi/eslint-config':
         specifier: ^0.3.7
-        version: 0.3.7(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+        version: 0.3.7(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       bumpp:
         specifier: ^10.2.0
         version: 10.2.0
@@ -68,7 +74,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
 
   example:
     devDependencies:
@@ -77,16 +83,16 @@ importers:
         version: 3.7.0
       '@sveltejs/adapter-auto':
         specifier: ^6.0.1
-        version: 6.0.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))
+        version: 6.0.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))
+        version: 3.0.8(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))
       '@sveltejs/kit':
         specifier: ^2.22.2
-        version: 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+        version: 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.0
-        version: 5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+        version: 5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -101,13 +107,13 @@ importers:
         version: 5.34.9
       svelte-check:
         specifier: ^4.2.2
-        version: 4.2.2(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3)
+        version: 4.2.2(picomatch@4.0.4)(svelte@5.34.9)(typescript@5.8.3)
       typescript:
         specifier: catalog:build
         version: 5.8.3
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+        version: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
       vite-plugin-favicons:
         specifier: workspace:*
         version: link:..
@@ -222,156 +228,6 @@ packages:
   '@es-joy/jsdoccomment@0.52.0':
     resolution: {integrity: sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==}
     engines: {node: '>=20.11.0'}
-
-  '@esbuild/aix-ppc64@0.25.5':
-    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.5':
-    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.5':
-    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.5':
-    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.5':
-    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.5':
-    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.5':
-    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.5':
-    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.5':
-    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.5':
-    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.5':
-    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.5':
-    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.5':
-    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.5':
-    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.5':
-    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.5':
-    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.5':
-    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.5':
-    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.5':
-    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/sunos-x64@0.25.5':
-    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.5':
-    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.5':
-    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.5':
-    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-plugin-eslint-comments@4.5.0':
     resolution: {integrity: sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==}
@@ -488,67 +344,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -586,6 +454,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -598,9 +472,16 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/runtime@0.101.0':
+    resolution: {integrity: sha512-t3qpfVZIqSiLQ5Kqt/MC4Ge/WCOGrrcagAdzTcDaggupjiGxUx4nJF2v6wUCXWSzWHn5Ns7XLv13fCJEwCOERQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/runtime@0.75.0':
     resolution: {integrity: sha512-gzRmVI/vorsPmbDXt7GD4Uh2lD3rCOku/1xWPB4Yx48k0EP4TZmzQudWapjN4+7Vv+rgXr0RqCHQadeaMvdBuw==}
     engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.101.0':
+    resolution: {integrity: sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==}
 
   '@oxc-project/types@0.75.0':
     resolution: {integrity: sha512-QMW+06WOXs7+F301Y3X0VpmWhwuQVc/X/RP2zF9OIwvSMmsif3xURS2wxbakFIABYsytgBcHpUcFepVS0Qnd3A==}
@@ -620,8 +501,20 @@ packages:
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
     engines: {node: '>=18'}
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.23':
     resolution: {integrity: sha512-rppgXFU4+dNDPQvPsfovUuYfDgMoATDomKGjIRR5bIU98BYkQF1fm+87trApilfWSosLQP9JsXOoUJO/EMrspQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
@@ -630,8 +523,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.53':
+    resolution: {integrity: sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.23':
     resolution: {integrity: sha512-/NzbXIFIR5KR+fZ351K1qONekakXpiPhUX55ydP6ok8iKdG7bTbgs6dlMg7Ow0E2DKlQoTbZbPTUY3kTzmNrsQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
+    resolution: {integrity: sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
@@ -640,33 +545,88 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.53':
+    resolution: {integrity: sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.23':
     resolution: {integrity: sha512-PFBBnj9JqLOL8gjZtoVGfOXe0PSpnPUXE+JuMcWz568K/p4Zzk7lDDHl7guD95wVtV89TmfaRwK2PWd9vKxHtg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
+    resolution: {integrity: sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.23':
     resolution: {integrity: sha512-KyQRLofVP78yUCXT90YmEzxK6I9VCBeOTSyOrs40Qx0Q0XwaGVwxo7sKj2SmnqxribdcouBA3CfNZC4ZNcyEnQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
+    resolution: {integrity: sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.23':
     resolution: {integrity: sha512-EubfEsJyjQbKK9j3Ez1hhbIOsttABb07Z7PhMRcVYW0wrVr8SfKLew9pULIMfcSNnoz8QqzoI4lOSmezJ9bYWw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
+    resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.23':
     resolution: {integrity: sha512-MUAthvl3I/+hySltZuj5ClKiq8fAMqExeBnxadLFShwWCbdHKFd+aRjBxxzarPcnqbDlTaOCUaAaYmQTOTOHSg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
+    resolution: {integrity: sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.23':
     resolution: {integrity: sha512-YI7QMQU01QFVNTEaQt3ysrq+wGBwLdFVFEGO64CoZ3gTsr/HulU8gvgR+67coQOlQC9iO/Hm1bvkBtceLxKrnA==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53':
+    resolution: {integrity: sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.23':
     resolution: {integrity: sha512-JdHx6Hli53etB/QsZL1tjpf4qa87kNcwPdx4iVicP/kL7po6k5bHoS5/l/nRRccwPh7BlPlB2uoEuTwJygJosQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
+    resolution: {integrity: sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
@@ -680,8 +640,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.53':
+    resolution: {integrity: sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.23':
     resolution: {integrity: sha512-lLCP4LUecUGBLq8EfkbY2esGYyvZj5ee+WZG12+mVnQH48b46SVbwp+0vJkD+6Pnsc+u9SWarBV9sQ5mVwmb5g==}
+
+  '@rolldown/pluginutils@1.0.0-beta.53':
+    resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
   '@ryoppippi/eslint-config@0.3.7':
     resolution: {integrity: sha512-T0dW35+AtaaBfm0Ta1zl8/Xn0PD5NJoajCDgKr16ywwmg9q0xWjfwYCBaCJr+6QAKHokUH6109Q/nUf30pq9nA==}
@@ -775,6 +744,9 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
@@ -822,6 +794,9 @@ packages:
 
   '@types/node@24.0.7':
     resolution: {integrity: sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -887,6 +862,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/eslint-plugin@1.3.3':
     resolution: {integrity: sha512-zOB4T5f80JXfP5DC2yQl7azRYq8PmGqYle3uxh3a0NnbKc+EaSYSpEcrVAh2r5W97pi3BVv7oRb5NdEQy0cCXA==}
@@ -1196,11 +1172,6 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  esbuild@0.25.5:
-    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1488,6 +1459,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1682,8 +1662,20 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1694,8 +1686,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.1:
     resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1706,32 +1710,76 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1742,8 +1790,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
@@ -2041,6 +2099,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -2050,6 +2112,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   pnpm-workspace-yaml@0.3.1:
     resolution: {integrity: sha512-3nW5RLmREmZ8Pm8MbPsO2RM+99RRjYd25ynj3NV0cFsN7CcEl4sDFzgoFmSyduFwxFQ2Qbu3y2UdCh6HlyUOeA==}
@@ -2171,6 +2237,7 @@ packages:
   rolldown-vite@7.0.4:
     resolution: {integrity: sha512-AcFt2mBWuwH3svDHcz8V5+K8Es1TuZOBDdJh6+ySkGSuNS5sEpRJqnopupeMfB8SHCAXVA6Wp75OQmTBZc+TgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    deprecated: Use 7.3.1 for migration purposes. For the most recent updates, migrate to Vite 8 once you're ready.
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
@@ -2208,8 +2275,54 @@ packages:
       yaml:
         optional: true
 
+  rolldown-vite@7.3.1:
+    resolution: {integrity: sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    deprecated: Use this package to migrate from Vite 7 to Vite 8. For the most recent updates, migrate to Vite 8 once you're ready.
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   rolldown@1.0.0-beta.23:
     resolution: {integrity: sha512-+/TR2YSZxLTtDAfG9LHlYqsHO6jtvr9qxaRD77E+PCAQi5X47bJkgiZsjDmE1jGR19NfYegWToOvSe6E+8NfwA==}
+    hasBin: true
+
+  rolldown@1.0.0-beta.53:
+    resolution: {integrity: sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -2346,6 +2459,10 @@ packages:
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -2553,7 +2670,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.10
       '@jridgewell/trace-mapping': 0.3.27
 
-  '@antfu/eslint-config@4.16.1(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))':
+  '@antfu/eslint-config@4.16.1(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
@@ -2562,7 +2679,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.1.0(eslint@9.30.1(jiti@2.4.2))
       '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.35.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@vitest/eslint-plugin': 1.3.3(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+      '@vitest/eslint-plugin': 1.3.3(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
       ansis: 4.1.0
       cac: 6.7.14
       eslint: 9.30.1(jiti@2.4.2)
@@ -2676,81 +2793,6 @@ snapshots:
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
-
-  '@esbuild/aix-ppc64@0.25.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/android-arm@0.25.5':
-    optional: true
-
-  '@esbuild/android-x64@0.25.5':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.5':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.5':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.5':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.5':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.5':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.5':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.5':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.5':
-    optional: true
 
   '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.30.1(jiti@2.4.2))':
     dependencies:
@@ -2946,6 +2988,13 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)':
+    dependencies:
+      '@emnapi/core': 1.4.3
+      '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2958,7 +3007,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxc-project/runtime@0.101.0': {}
+
   '@oxc-project/runtime@0.75.0': {}
+
+  '@oxc-project/types@0.101.0': {}
 
   '@oxc-project/types@0.75.0': {}
 
@@ -2970,28 +3023,58 @@ snapshots:
 
   '@publint/pack@0.1.2': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.23':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.23':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.23':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.23':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.23':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.23':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.23':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.23':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.23':
@@ -2999,7 +3082,18 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.11
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.23':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.23':
@@ -3008,11 +3102,16 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.23':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.53':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.23': {}
 
-  '@ryoppippi/eslint-config@0.3.7(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))':
+  '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@ryoppippi/eslint-config@0.3.7(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
-      '@antfu/eslint-config': 4.16.1(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+      '@antfu/eslint-config': 4.16.1(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.34.9))(eslint@9.30.1(jiti@2.4.2))(svelte-eslint-parser@1.2.0(svelte@5.34.9))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
       eslint: 9.30.1(jiti@2.4.2)
       eslint-flat-config-utils: 2.1.0
       eslint-plugin-ryoppippi: 0.2.6(eslint@9.30.1(jiti@2.4.2))
@@ -3090,18 +3189,18 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))':
+  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))':
     dependencies:
-      '@sveltejs/kit': 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+      '@sveltejs/kit': 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))':
     dependencies:
-      '@sveltejs/kit': 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+      '@sveltejs/kit': 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
 
-  '@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
+  '@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+      '@sveltejs/vite-plugin-svelte': 5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -3114,30 +3213,35 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.34.9
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
-      vitefu: 1.0.7(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
+      vitefu: 1.0.7(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+      '@sveltejs/vite-plugin-svelte': 5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
       debug: 4.4.1
       svelte: 5.34.9
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
+  '@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9))(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))(svelte@5.34.9)
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.34.9
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
-      vitefu: 1.0.7(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
+      vitefu: 1.0.7(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -3191,6 +3295,10 @@ snapshots:
   '@types/node@24.0.7':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 24.0.7
 
   '@types/unist@3.0.3': {}
 
@@ -3288,13 +3396,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/eslint-plugin@1.3.3(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))':
+  '@vitest/eslint-plugin@1.3.3(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@typescript-eslint/utils': 8.35.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.30.1(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3306,13 +3414,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3599,35 +3707,6 @@ snapshots:
   entities@4.5.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  esbuild@0.25.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.5
-      '@esbuild/android-arm': 0.25.5
-      '@esbuild/android-arm64': 0.25.5
-      '@esbuild/android-x64': 0.25.5
-      '@esbuild/darwin-arm64': 0.25.5
-      '@esbuild/darwin-x64': 0.25.5
-      '@esbuild/freebsd-arm64': 0.25.5
-      '@esbuild/freebsd-x64': 0.25.5
-      '@esbuild/linux-arm': 0.25.5
-      '@esbuild/linux-arm64': 0.25.5
-      '@esbuild/linux-ia32': 0.25.5
-      '@esbuild/linux-loong64': 0.25.5
-      '@esbuild/linux-mips64el': 0.25.5
-      '@esbuild/linux-ppc64': 0.25.5
-      '@esbuild/linux-riscv64': 0.25.5
-      '@esbuild/linux-s390x': 0.25.5
-      '@esbuild/linux-x64': 0.25.5
-      '@esbuild/netbsd-arm64': 0.25.5
-      '@esbuild/netbsd-x64': 0.25.5
-      '@esbuild/openbsd-arm64': 0.25.5
-      '@esbuild/openbsd-x64': 0.25.5
-      '@esbuild/sunos-x64': 0.25.5
-      '@esbuild/win32-arm64': 0.25.5
-      '@esbuild/win32-ia32': 0.25.5
-      '@esbuild/win32-x64': 0.25.5
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -4002,6 +4081,14 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.4.6(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4175,34 +4262,67 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -4219,6 +4339,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@2.1.0: {}
 
@@ -4695,6 +4831,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.4: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -4708,6 +4846,8 @@ snapshots:
       pathe: 2.0.3
 
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
 
   pnpm-workspace-yaml@0.3.1:
     dependencies:
@@ -4807,7 +4947,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0):
+  rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       '@oxc-project/runtime': 0.75.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -4818,10 +4958,27 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.0.7
-      esbuild: 0.25.5
       fsevents: 2.3.3
       jiti: 2.4.2
       yaml: 2.8.0
+
+  rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0):
+    dependencies:
+      '@oxc-project/runtime': 0.101.0
+      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rolldown: 1.0.0-beta.53(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.0.7
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      yaml: 2.8.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   rolldown@1.0.0-beta.23:
     dependencies:
@@ -4842,6 +4999,28 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.23
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.23
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.23
+
+  rolldown@1.0.0-beta.53(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3):
+    dependencies:
+      '@oxc-project/types': 0.101.0
+      '@rolldown/pluginutils': 1.0.0-beta.53
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.53
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.53
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.53
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.53
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.53
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.53
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.53
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.53(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.53
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.53
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   run-parallel@1.2.0:
     dependencies:
@@ -4956,11 +5135,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-check@4.2.2(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3):
+  svelte-check@4.2.2(picomatch@4.0.4)(svelte@5.34.9)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.27
       chokidar: 4.0.3
-      fdir: 6.4.6(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.34.9
@@ -5017,6 +5196,11 @@ snapshots:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -5110,13 +5294,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -5131,15 +5315,15 @@ snapshots:
       - tsx
       - yaml
 
-  vitefu@1.0.7(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)):
+  vitefu@1.0.7(rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)):
     optionalDependencies:
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.4.3)(@emnapi/runtime@1.4.3)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5157,8 +5341,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.7)(esbuild@0.25.5)(jiti@2.4.2)(yaml@2.8.0)
+      vite: rolldown-vite@7.0.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.7)(jiti@2.4.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   .:
     dependencies:
+      bun:
+        specifier: runtime:^1.3.14
+        version: runtime:1.3.14
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -26,6 +29,9 @@ importers:
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.22.3
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -991,6 +997,115 @@ packages:
   bumpp@10.2.0:
     resolution: {integrity: sha512-1EJ2NG3M3WYJj4m+GtcxNH6Y7zMQ8q68USMoUGKjM6qFTVXSXCnTxcQSUDV7j4KjLVbk2uK6345Z+6RKOv0w5A==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  bun@runtime:1.3.14:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=
+            prefix: bun-darwin-aarch64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-QYPfM3RiPlurMVxUfPoJdFM81FfYa3O2OfeoeXTNZjM=
+            prefix: bun-darwin-x64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64.zip
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-c8XBkFn95AkTf8bLq1kF/Hxa+ljOYOQaQaUhwj//Zrs=
+            prefix: bun-freebsd-aarch64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-aarch64.zip
+          targets:
+            - cpu: arm64
+              os: freebsd
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-uIHcTdvWjHmjW9NUkIi9HXADtWLOw8t5VMDKi29SiKU=
+            prefix: bun-freebsd-x64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-freebsd-x64.zip
+          targets:
+            - cpu: x64
+              os: freebsd
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-uY4K02JcXADR1bX/VWBcet3b+uFRhh5oreV7LTuHA7s=
+            prefix: bun-linux-aarch64-musl
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64-musl.zip
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=
+            prefix: bun-linux-aarch64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-FL2a7e6/Hbpn6N75UxyJvJiez98d5C5b/K8bjNkpRxk=
+            prefix: bun-linux-x64-musl
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl.zip
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: zip
+            bin: bun
+            integrity: sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=
+            prefix: bun-linux-x64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: bun.exe
+            integrity: sha256-iYQfWlfyNItn7Ag5txj0v06n0Hw3HJukt3tseQ+RiVM=
+            prefix: bun-windows-aarch64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-aarch64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: bun.exe
+            integrity: sha256-CgYgkwtmdde6RA6B9ODgDTz74JbEsUDT//AiBenhiSI=
+            prefix: bun-windows-x64
+            type: binary
+            url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+    version: 1.3.14
     hasBin: true
 
   c12@3.0.4:
@@ -2023,6 +2138,115 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node@runtime:22.22.3:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-QAJqz3ioCOQ9IioLDg5xG5X/J5NGlreSW1Mpi8fIxgo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-Daf/dO+GETKMghLxeUM2hxOirZU/t9iajIoOrofCMgc=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-RYMLp1L6DYksbc1kCUZmmAEpPKyCCjNZHe1ArAdRmOw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-zIvIKy3QtZXDuVpMPJyMNQkHz/ARr73uPRN56BLh4+M=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-GPvhv91CBFrxXwIlauPllJDRuf+T38J6IjrMLJJ0AlA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-qQ9SPPFk4cdhv0xZtcaqDZ1VKJJwGraUmeaD7h/Aa7w=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-S4TkPCnZDk+QGBXDmRBqSa9O5zDRKTOvgsgtTcRQMIw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-x6ENaBbajqqnU03XPHHG4rLDkdu/hF42SQLRVmFd0bg=
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-AL4SmgnohyzVLTu4u6EkEsVzPSIkEjpIKi3KSm+/JYY=
+            prefix: node-v22.22.3-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-bI1U9jX+/033bCyoD0UzLrL/V9JSJu3ONlkuUaF37jM=
+            prefix: node-v22.22.3-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-e6QmD2nha6libQd8sRJPP7AfYEIa8qbHOWrrTi0Nja4=
+            prefix: node-v22.22.3-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.22.3/node-v22.22.3-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.22.3
+    hasBin: true
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -3553,6 +3777,8 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  bun@runtime:1.3.14: {}
+
   c12@3.0.4:
     dependencies:
       chokidar: 4.0.3
@@ -4761,6 +4987,8 @@ snapshots:
   node-fetch-native@1.6.6: {}
 
   node-releases@2.0.19: {}
+
+  node@runtime:22.22.3: {}
 
   nth-check@2.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,5 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
   - unrs-resolver
-useNodeVersion: 22.15.0
 allowBuilds:
   sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,5 @@ onlyBuiltDependencies:
   - sharp
   - unrs-resolver
 useNodeVersion: 22.15.0
+allowBuilds:
+  sharp: true

--- a/src/bun-image-sharp.js
+++ b/src/bun-image-sharp.js
@@ -1,0 +1,333 @@
+import { Buffer } from 'node:buffer';
+import { PNG } from 'pngjs';
+
+const TRANSPARENT = { r: 0, g: 0, b: 0, a: 0 };
+const WHITE = { r: 255, g: 255, b: 255, a: 255 };
+const BLACK = { r: 0, g: 0, b: 0, a: 255 };
+
+const sharp = Object.assign(
+	(input, options) => new BunImageSharpPipeline(input, options),
+	{
+		fit: {
+			contain: 'contain',
+		},
+	},
+);
+
+let registered = false;
+
+export function registerBunImageSharpModule() {
+	assertBunImage();
+
+	if (registered) {
+		return;
+	}
+
+	globalThis.Bun.plugin({
+		name: 'vite-plugin-favicons:bun-image-sharp',
+		setup(builder) {
+			builder.module('sharp', () => ({
+				loader: 'object',
+				exports: {
+					default: sharp,
+				},
+			}));
+		},
+	});
+
+	registered = true;
+}
+
+function assertBunImage() {
+	if (!globalThis.Bun?.Image) {
+		throw new Error('Bun.Image is required when useBunImage is enabled');
+	}
+}
+
+class BunImageSharpPipeline {
+	#input;
+	#options;
+	#resize;
+	#overlays = [];
+	#rotate = 0;
+	#format;
+	#raw = false;
+	#colorspace;
+
+	constructor(input, options = {}) {
+		this.#input = input;
+		this.#options = options;
+	}
+
+	async metadata() {
+		assertBunImage();
+
+		if (this.#input?.create) {
+			return {
+				width: this.#input.create.width,
+				height: this.#input.create.height,
+				format: 'png',
+			};
+		}
+
+		const svgMetadata = readSvgMetadata(this.#input);
+		if (svgMetadata) {
+			return svgMetadata;
+		}
+
+		return await new globalThis.Bun.Image(this.#input, this.#options).metadata();
+	}
+
+	ensureAlpha() {
+		return this;
+	}
+
+	resize(options) {
+		this.#resize = options;
+		return this;
+	}
+
+	composite(overlays) {
+		this.#overlays = overlays;
+		return this;
+	}
+
+	rotate(degrees = 90) {
+		this.#rotate = degrees;
+		return this;
+	}
+
+	toColorspace(colorspace) {
+		this.#colorspace = colorspace;
+		return this;
+	}
+
+	raw() {
+		this.#raw = true;
+		return this;
+	}
+
+	png() {
+		this.#format = 'png';
+		return this;
+	}
+
+	async toBuffer(options = {}) {
+		const png = await this.#toPng();
+
+		if (!this.#raw) {
+			return PNG.sync.write(png);
+		}
+
+		const data = Buffer.from(png.data);
+
+		if (options.resolveWithObject) {
+			return {
+				data,
+				info: {
+					width: png.width,
+					height: png.height,
+					channels: 4,
+					size: data.length,
+					format: this.#format ?? 'raw',
+					space: this.#colorspace,
+				},
+			};
+		}
+
+		return data;
+	}
+
+	async #toPng() {
+		const png = this.#input?.create
+			? createBlankPng(this.#input.create)
+			: await this.#loadPng();
+
+		let output = png;
+
+		for (const overlay of this.#overlays) {
+			const input = PNG.sync.read(Buffer.from(overlay.input));
+			compositePng(output, input, overlay.left ?? 0, overlay.top ?? 0);
+		}
+
+		if (this.#rotate % 360 !== 0) {
+			output = rotatePng(output, this.#rotate);
+		}
+
+		return output;
+	}
+
+	async #loadPng() {
+		assertBunImage();
+
+		const image = new globalThis.Bun.Image(this.#input, this.#options);
+		const pipeline = this.#resize
+			? image.resize(this.#resize.width, this.#resize.height, {
+					fit: this.#resize.fit === sharp.fit.contain ? 'inside' : 'fill',
+					filter: this.#resize.kernel,
+				})
+			: image;
+
+		const buffer = await pipeline.png().buffer();
+		const png = PNG.sync.read(Buffer.from(buffer));
+
+		if (!this.#resize) {
+			return png;
+		}
+
+		if (png.width === this.#resize.width && png.height === this.#resize.height) {
+			return png;
+		}
+
+		const canvas = createBlankPng({
+			width: this.#resize.width,
+			height: this.#resize.height,
+			channels: 4,
+			background: this.#resize.background,
+		});
+		const left = Math.floor((canvas.width - png.width) / 2);
+		const top = Math.floor((canvas.height - png.height) / 2);
+		compositePng(canvas, png, left, top);
+		return canvas;
+	}
+}
+
+function createBlankPng(options) {
+	const png = new PNG({
+		width: options.width,
+		height: options.height,
+	});
+	const color = parseColor(options.background, options.channels);
+
+	for (let offset = 0; offset < png.data.length; offset += 4) {
+		png.data[offset] = color.r;
+		png.data[offset + 1] = color.g;
+		png.data[offset + 2] = color.b;
+		png.data[offset + 3] = color.a;
+	}
+
+	return png;
+}
+
+function parseColor(background, channels = 4) {
+	if (!background || background === 'transparent') {
+		return channels === 3 ? WHITE : TRANSPARENT;
+	}
+
+	if (background === 'white') {
+		return WHITE;
+	}
+
+	if (background === 'black') {
+		return BLACK;
+	}
+
+	if (typeof background !== 'string' || !background.startsWith('#')) {
+		return WHITE;
+	}
+
+	const hex = background.slice(1);
+	const values = hex.length <= 4
+		? [...hex].map(value => Number.parseInt(value + value, 16))
+		: hex.match(/.{1,2}/g).map(value => Number.parseInt(value, 16));
+
+	return {
+		r: values[0] ?? 255,
+		g: values[1] ?? 255,
+		b: values[2] ?? 255,
+		a: values[3] ?? 255,
+	};
+}
+
+function compositePng(base, overlay, left, top) {
+	for (let y = 0; y < overlay.height; y += 1) {
+		for (let x = 0; x < overlay.width; x += 1) {
+			const targetX = x + left;
+			const targetY = y + top;
+
+			if (targetX < 0 || targetY < 0 || targetX >= base.width || targetY >= base.height) {
+				continue;
+			}
+
+			const sourceOffset = (y * overlay.width + x) * 4;
+			const targetOffset = (targetY * base.width + targetX) * 4;
+			const sourceAlpha = overlay.data[sourceOffset + 3] / 255;
+			const targetAlpha = base.data[targetOffset + 3] / 255;
+			const outputAlpha = sourceAlpha + targetAlpha * (1 - sourceAlpha);
+
+			if (outputAlpha === 0) {
+				base.data[targetOffset] = 0;
+				base.data[targetOffset + 1] = 0;
+				base.data[targetOffset + 2] = 0;
+				base.data[targetOffset + 3] = 0;
+				continue;
+			}
+
+			for (let channel = 0; channel < 3; channel += 1) {
+				base.data[targetOffset + channel] = Math.round(
+					(overlay.data[sourceOffset + channel] * sourceAlpha
+						+ base.data[targetOffset + channel] * targetAlpha * (1 - sourceAlpha))
+					/ outputAlpha,
+				);
+			}
+
+			base.data[targetOffset + 3] = Math.round(outputAlpha * 255);
+		}
+	}
+}
+
+function rotatePng(png, degrees) {
+	const normalized = ((degrees % 360) + 360) % 360;
+
+	if (normalized === 0) {
+		return png;
+	}
+
+	if (normalized !== 90) {
+		throw new Error(`Bun.Image sharp shim only supports 90 degree rotation`);
+	}
+
+	const rotated = new PNG({
+		width: png.height,
+		height: png.width,
+	});
+
+	for (let y = 0; y < png.height; y += 1) {
+		for (let x = 0; x < png.width; x += 1) {
+			const sourceOffset = (y * png.width + x) * 4;
+			const targetX = png.height - y - 1;
+			const targetY = x;
+			const targetOffset = (targetY * rotated.width + targetX) * 4;
+			png.data.copy(rotated.data, targetOffset, sourceOffset, sourceOffset + 4);
+		}
+	}
+
+	return rotated;
+}
+
+function readSvgMetadata(input) {
+	if (!Buffer.isBuffer(input)) {
+		return;
+	}
+
+	const source = input.toString('utf8');
+	if (!source.trimStart().startsWith('<svg')) {
+		return;
+	}
+
+	const width = Number.parseFloat(source.match(/\bwidth=["']?([0-9.]+)/)?.[1]);
+	const height = Number.parseFloat(source.match(/\bheight=["']?([0-9.]+)/)?.[1]);
+	const viewBox = source.match(/\bviewBox=["']?([0-9.\s-]+)/)?.[1]
+		?.trim()
+		.split(/\s+/)
+		.map(value => Number.parseFloat(value));
+
+	return {
+		width: Number.isFinite(width) ? width : viewBox?.[2],
+		height: Number.isFinite(height) ? height : viewBox?.[3],
+		format: 'svg',
+		density: 72,
+	};
+}
+
+export default sharp;

--- a/src/bun-image-sharp.js
+++ b/src/bun-image-sharp.js
@@ -5,6 +5,7 @@ import { PNG } from 'pngjs';
 const TRANSPARENT = { r: 0, g: 0, b: 0, a: 0 };
 const WHITE = { r: 255, g: 255, b: 255, a: 255 };
 const BLACK = { r: 0, g: 0, b: 0, a: 255 };
+// Bun.Image is faster for small resize-only icons, while sharp wins for larger favicon outputs.
 const BUN_IMAGE_MAX_PIXELS = 192 * 192;
 const require = createRequire(import.meta.url);
 const realSharp = createRequire(require.resolve('favicons'))('sharp');

--- a/src/bun-image-sharp.js
+++ b/src/bun-image-sharp.js
@@ -1,9 +1,13 @@
 import { Buffer } from 'node:buffer';
+import { createRequire } from 'node:module';
 import { PNG } from 'pngjs';
 
 const TRANSPARENT = { r: 0, g: 0, b: 0, a: 0 };
 const WHITE = { r: 255, g: 255, b: 255, a: 255 };
 const BLACK = { r: 0, g: 0, b: 0, a: 255 };
+const BUN_IMAGE_MAX_PIXELS = 512 * 512;
+const require = createRequire(import.meta.url);
+const realSharp = createRequire(require.resolve('favicons'))('sharp');
 
 const sharp = Object.assign(
 	(input, options) => new BunImageSharpPipeline(input, options),
@@ -49,25 +53,27 @@ class BunImageSharpPipeline {
 	#options;
 	#resize;
 	#overlays = [];
-	#rotate = 0;
+	#rotate;
 	#format;
-	#raw = false;
+	#rawOptions;
 	#colorspace;
+	#ensureAlpha = false;
+	#delegate;
 
-	constructor(input, options = {}) {
+	constructor(input, options) {
 		this.#input = input;
 		this.#options = options;
+
+		if (input?.create) {
+			this.#delegateToSharp();
+		}
 	}
 
 	async metadata() {
 		assertBunImage();
 
-		if (this.#input?.create) {
-			return {
-				width: this.#input.create.width,
-				height: this.#input.create.height,
-				format: 'png',
-			};
+		if (this.#delegate) {
+			return await this.#delegate.metadata();
 		}
 
 		const svgMetadata = readSvgMetadata(this.#input);
@@ -79,49 +85,87 @@ class BunImageSharpPipeline {
 	}
 
 	ensureAlpha() {
+		this.#ensureAlpha = true;
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.ensureAlpha();
+		}
 		return this;
 	}
 
 	resize(options) {
 		this.#resize = options;
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.resize(options);
+		}
 		return this;
 	}
 
 	composite(overlays) {
 		this.#overlays = overlays;
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.composite(overlays);
+		}
+		else {
+			this.#delegateToSharp();
+		}
 		return this;
 	}
 
 	rotate(degrees = 90) {
 		this.#rotate = degrees;
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.rotate(degrees);
+		}
+		else {
+			this.#delegateToSharp();
+		}
 		return this;
 	}
 
 	toColorspace(colorspace) {
 		this.#colorspace = colorspace;
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.toColorspace(colorspace);
+		}
 		return this;
 	}
 
-	raw() {
-		this.#raw = true;
+	raw(options) {
+		this.#rawOptions = options ?? {};
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.raw(this.#rawOptions);
+		}
+		else {
+			this.#delegateToSharp();
+		}
 		return this;
 	}
 
 	png() {
 		this.#format = 'png';
+		if (this.#delegate) {
+			this.#delegate = this.#delegate.png();
+		}
 		return this;
 	}
 
-	async toBuffer(options = {}) {
+	async toBuffer(options) {
+		if (this.#delegate || !this.#canUseBunImage()) {
+			const pipeline = this.#delegateToSharp();
+			return options === undefined
+				? await pipeline.toBuffer()
+				: await pipeline.toBuffer(options);
+		}
+
 		const png = await this.#toPng();
 
-		if (!this.#raw) {
+		if (!this.#rawOptions) {
 			return PNG.sync.write(png);
 		}
 
 		const data = Buffer.from(png.data);
 
-		if (options.resolveWithObject) {
+		if (options?.resolveWithObject) {
 			return {
 				data,
 				info: {
@@ -139,22 +183,7 @@ class BunImageSharpPipeline {
 	}
 
 	async #toPng() {
-		const png = this.#input?.create
-			? createBlankPng(this.#input.create)
-			: await this.#loadPng();
-
-		let output = png;
-
-		for (const overlay of this.#overlays) {
-			const input = PNG.sync.read(Buffer.from(overlay.input));
-			compositePng(output, input, overlay.left ?? 0, overlay.top ?? 0);
-		}
-
-		if (this.#rotate % 360 !== 0) {
-			output = rotatePng(output, this.#rotate);
-		}
-
-		return output;
+		return await this.#loadPng();
 	}
 
 	async #loadPng() {
@@ -189,6 +218,56 @@ class BunImageSharpPipeline {
 		const top = Math.floor((canvas.height - png.height) / 2);
 		compositePng(canvas, png, left, top);
 		return canvas;
+	}
+
+	#delegateToSharp() {
+		if (this.#delegate) {
+			return this.#delegate;
+		}
+
+		let pipeline = this.#options === undefined
+			? realSharp(this.#input)
+			: realSharp(this.#input, this.#options);
+
+		if (this.#ensureAlpha) {
+			pipeline = pipeline.ensureAlpha();
+		}
+
+		if (this.#resize) {
+			pipeline = pipeline.resize(this.#resize);
+		}
+
+		if (this.#overlays.length > 0) {
+			pipeline = pipeline.composite(this.#overlays);
+		}
+
+		if (this.#rotate !== undefined) {
+			pipeline = pipeline.rotate(this.#rotate);
+		}
+
+		if (this.#colorspace) {
+			pipeline = pipeline.toColorspace(this.#colorspace);
+		}
+
+		if (this.#rawOptions) {
+			pipeline = pipeline.raw(this.#rawOptions);
+		}
+
+		if (this.#format === 'png') {
+			pipeline = pipeline.png();
+		}
+
+		this.#delegate = pipeline;
+		return this.#delegate;
+	}
+
+	#canUseBunImage() {
+		if (!this.#resize || this.#overlays.length > 0 || this.#rotate !== undefined || this.#rawOptions) {
+			return false;
+		}
+
+		const { width, height } = this.#resize;
+		return width * height <= BUN_IMAGE_MAX_PIXELS;
 	}
 }
 
@@ -274,35 +353,6 @@ function compositePng(base, overlay, left, top) {
 			base.data[targetOffset + 3] = Math.round(outputAlpha * 255);
 		}
 	}
-}
-
-function rotatePng(png, degrees) {
-	const normalized = ((degrees % 360) + 360) % 360;
-
-	if (normalized === 0) {
-		return png;
-	}
-
-	if (normalized !== 90) {
-		throw new Error(`Bun.Image sharp shim only supports 90 degree rotation`);
-	}
-
-	const rotated = new PNG({
-		width: png.height,
-		height: png.width,
-	});
-
-	for (let y = 0; y < png.height; y += 1) {
-		for (let x = 0; x < png.width; x += 1) {
-			const sourceOffset = (y * png.width + x) * 4;
-			const targetX = png.height - y - 1;
-			const targetY = x;
-			const targetOffset = (targetY * rotated.width + targetX) * 4;
-			png.data.copy(rotated.data, targetOffset, sourceOffset, sourceOffset + 4);
-		}
-	}
-
-	return rotated;
 }
 
 function readSvgMetadata(input) {

--- a/src/bun-image-sharp.js
+++ b/src/bun-image-sharp.js
@@ -5,7 +5,7 @@ import { PNG } from 'pngjs';
 const TRANSPARENT = { r: 0, g: 0, b: 0, a: 0 };
 const WHITE = { r: 255, g: 255, b: 255, a: 255 };
 const BLACK = { r: 0, g: 0, b: 0, a: 255 };
-const BUN_IMAGE_MAX_PIXELS = 512 * 512;
+const BUN_IMAGE_MAX_PIXELS = 192 * 192;
 const require = createRequire(import.meta.url);
 const realSharp = createRequire(require.resolve('favicons'))('sharp');
 

--- a/src/index.bun.js
+++ b/src/index.bun.js
@@ -1,7 +1,7 @@
 import { faviconsPlugin as baseFaviconsPlugin } from './index.js';
 
 /**
- * Favicon plugin for Vite using Bun.Image by default.
+ * Favicon plugin for Vite using Bun.Image by default with sharp fallback.
  * @param {import('./index').Options} options - The plugin options.
  * @returns {import('vite').Plugin} - The Vite plugin object.
  */

--- a/src/index.bun.js
+++ b/src/index.bun.js
@@ -1,0 +1,13 @@
+import { faviconsPlugin as baseFaviconsPlugin } from './index.js';
+
+/**
+ * Favicon plugin for Vite using Bun.Image by default.
+ * @param {import('./index').Options} options - The plugin options.
+ * @returns {import('vite').Plugin} - The Vite plugin object.
+ */
+export function faviconsPlugin(options) {
+	return baseFaviconsPlugin({
+		useBunImage: true,
+		...options,
+	});
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,9 @@ export interface Options extends FaviconOptions {
 
 	/** whether to cache the generated favicons (default: false on Production, true on Development) */
 	cache?: boolean;
+
+	/** whether to replace favicons' sharp dependency with Bun.Image through Bun.module */
+	useBunImage?: boolean;
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,7 +21,7 @@ export interface Options extends FaviconOptions {
 	/** whether to cache the generated favicons (default: false on Production, true on Development) */
 	cache?: boolean;
 
-	/** whether to replace favicons' sharp dependency with Bun.Image through Bun.module */
+	/** whether to use Bun.Image through Bun.module with sharp fallback for unsupported image operations */
 	useBunImage?: boolean;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto';
-import { favicons } from 'favicons';
 import fs from 'fs-extra';
 import path from 'pathe';
 import { isProduction } from 'std-env';
@@ -8,6 +7,16 @@ import { logger } from './logger.js';
 
 const virtualModuleId = `virtual:favicons`;
 const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+async function getFavicons(useBunImage) {
+	if (useBunImage) {
+		const { registerBunImageSharpModule } = await import('./bun-image-sharp.js');
+		registerBunImageSharpModule();
+	}
+
+	const module = await import('favicons');
+	return module.favicons;
+}
 
 /**
  * Get the parent directory path of a given path.
@@ -27,6 +36,7 @@ export function faviconsPlugin(options) {
 	const {
 		imgSrc,
 		cache = !isProduction,
+		useBunImage = false,
 		...faviconConfig
 	} = options;
 
@@ -105,7 +115,8 @@ export function faviconsPlugin(options) {
 			await fs.mkdir(getParentDirPath(htmlDest), { recursive: true });
 
 			/* Generate favicons */
-			const response = await favicons(imgSrc, faviconConfig);
+			const generateFavicons = await getFavicons(useBunImage);
+			const response = await generateFavicons(imgSrc, faviconConfig);
 
 			await Promise.all([
 				/* Write the generated favicon images */

--- a/tests/bun-image-sharp.test.ts
+++ b/tests/bun-image-sharp.test.ts
@@ -1,0 +1,184 @@
+import { Buffer } from 'node:buffer';
+import { PNG } from 'pngjs';
+import { afterEach, expect, it } from 'vitest';
+
+import sharp, { registerBunImageSharpModule } from '../src/bun-image-sharp.js';
+
+type Metadata = {
+	width: number;
+	height: number;
+	format: string;
+};
+
+type RawBuffer = {
+	data: Buffer;
+	info: {
+		width: number;
+		height: number;
+		channels: number;
+	};
+};
+
+type SharpPipeline = {
+	metadata: () => Promise<Metadata>;
+	ensureAlpha: () => SharpPipeline;
+	resize: (options: {
+		width: number;
+		height: number;
+		fit: string;
+		background: string;
+		kernel: string;
+	}) => SharpPipeline;
+	composite: (overlays: Array<{ input: Buffer; left: number; top: number }>) => SharpPipeline;
+	raw: () => SharpRawPipeline;
+	toBuffer: () => Promise<Buffer>;
+};
+
+type SharpRawPipeline = Omit<SharpPipeline, 'toBuffer'> & {
+	toBuffer: (options: { resolveWithObject: true }) => Promise<RawBuffer>;
+};
+
+type SharpFunction = ((input: unknown, options?: unknown) => SharpPipeline) & {
+	fit: {
+		contain: string;
+	};
+};
+
+type BunModuleCallback = () => {
+	loader: string;
+	exports: {
+		default: typeof sharp;
+	};
+};
+
+const bunSharp = sharp as unknown as SharpFunction;
+
+type MinimalBun = {
+	Image: typeof FakeImage;
+	plugin: (plugin: {
+		name: string;
+		setup: (builder: {
+			module: (specifier: string, callback: BunModuleCallback) => unknown;
+		}) => void;
+	}) => void;
+};
+
+const globalWithBun = globalThis as typeof globalThis & { Bun?: MinimalBun };
+const originalBun = globalWithBun.Bun;
+
+afterEach(() => {
+	globalWithBun.Bun = originalBun;
+});
+
+it('registers a Bun.module replacement for sharp', () => {
+	const modules = new Map<string, BunModuleCallback>();
+	globalWithBun.Bun = {
+		Image: FakeImage,
+		plugin(plugin) {
+			plugin.setup({
+				module(specifier, callback) {
+					modules.set(specifier, callback);
+					return this;
+				},
+			});
+		},
+	};
+
+	registerBunImageSharpModule();
+
+	const module = modules.get('sharp')?.();
+	expect(module?.loader).toBe('object');
+	expect(module?.exports.default).toBe(sharp);
+});
+
+it('uses Bun.Image output for resize, composite, and raw buffers', async () => {
+	globalWithBun.Bun = {
+		Image: FakeImage,
+		plugin() {},
+	};
+
+	const source = createPng(4, 2, { r: 255, g: 0, b: 0, a: 255 });
+	const metadata = await bunSharp(source).metadata();
+	expect(metadata).toMatchObject({ width: 4, height: 2, format: 'png' });
+
+	const resized = await bunSharp(source)
+		.ensureAlpha()
+		.resize({
+			width: 2,
+			height: 2,
+			fit: bunSharp.fit.contain,
+			background: '#00000000',
+			kernel: 'nearest',
+		})
+		.toBuffer();
+
+	const raw = await bunSharp({
+		create: {
+			width: 4,
+			height: 4,
+			channels: 4,
+			background: '#00000000',
+		},
+	})
+		.composite([{ input: resized, left: 1, top: 1 }])
+		.raw()
+		.toBuffer({ resolveWithObject: true });
+
+	expect(raw.info).toMatchObject({ width: 4, height: 4, channels: 4 });
+	expect(raw.data[(1 * 4 + 1) * 4]).toBe(255);
+	expect(raw.data[(1 * 4 + 1) * 4 + 3]).toBe(255);
+});
+
+class FakeImage {
+	#png: PNG;
+	#resize?: { width: number; height: number };
+
+	constructor(input: Buffer) {
+		this.#png = PNG.sync.read(Buffer.from(input));
+	}
+
+	async metadata() {
+		return {
+			width: this.#png.width,
+			height: this.#png.height,
+			format: 'png',
+		};
+	}
+
+	resize(width: number, height: number) {
+		this.#resize = { width, height };
+		return this;
+	}
+
+	png() {
+		return this;
+	}
+
+	async buffer() {
+		const width = this.#resize?.width ?? this.#png.width;
+		const height = this.#resize?.height ?? this.#png.height;
+		const output = new PNG({ width, height });
+
+		for (let index = 0; index < output.data.length; index += 4) {
+			output.data[index] = this.#png.data[0];
+			output.data[index + 1] = this.#png.data[1];
+			output.data[index + 2] = this.#png.data[2];
+			output.data[index + 3] = this.#png.data[3];
+		}
+
+		return PNG.sync.write(output);
+	}
+}
+
+function createPng(width: number, height: number, color: { r: number; g: number; b: number; a: number }) {
+	const png = new PNG({ width, height });
+
+	for (let index = 0; index < png.data.length; index += 4) {
+		png.data[index] = color.r;
+		png.data[index + 1] = color.g;
+		png.data[index + 2] = color.b;
+		png.data[index + 3] = color.a;
+	}
+
+	return PNG.sync.write(png);
+}

--- a/tests/bun-image-sharp.test.ts
+++ b/tests/bun-image-sharp.test.ts
@@ -91,7 +91,7 @@ it('registers a Bun.module replacement for sharp', () => {
 	expect(module?.exports.default).toBe(sharp);
 });
 
-it('uses Bun.Image output for resize, composite, and raw buffers', async () => {
+it('uses Bun.Image for resize and sharp fallback for raw buffers', async () => {
 	globalWithBun.Bun = {
 		Image: FakeImage,
 		plugin() {},


### PR DESCRIPTION
Summary:
- Adds an opt-in useBunImage option that registers a Bun.module replacement for favicons' sharp import before favicons loads.
- Implements the sharp subset favicons uses with Bun.Image plus PNG handling for composite/raw ICO buffers.
- Updates pnpm to 11.1.2, refreshes the lockfile, and fixes the Vite peer range for stricter pnpm semver validation.

Testing:
- pnpm lint
- pnpm release:pre
- bun -e "function fake(){} fake.fit={contain:'contain'}; Bun.plugin({name:'override-sharp', setup(b){b.module('sharp', () => ({loader:'object', exports:{default:fake}}))}}); const m = await import('favicons'); console.log(typeof m.favicons)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Bun-based image handling and a Bun-targeted plugin entrypoint
  * Introduced required path option and enhanced cache option behavior

* **Documentation**
  * README updated to document path, cache, and useBunImage options; removed deprecated faviconAssetsDest

* **Tests**
  * Added integration tests for the Bun image integration

* **Chores**
  * Package metadata and CI/workflow action versions updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/vite-plugin-favicons/pull/544)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->