### PR TITLE
feat: dedupe favicon generation within a single process

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The plugin accepts the following options:
 
 - `imgSrc` (required): Path to the source image for generating favicons
 - `faviconAssetsDest` (optional): Output path for favicon images and manifest (default: `${assetsDir}/favicons`)
+- `cache` (optional): Reuse the previously generated favicons from disk across builds (default: `false` in production, `true` in development)
+- `dedupe` (optional): Collapse identical favicon generations within a single Node process into one run. This prevents double generation when one `vite build` runs the plugin more than once, e.g. SvelteKit's client and server builds (default: `true`)
 - Other options from the `Favicons` package
 
 The additional options are based on the `Favicons` library. For a full list of options and their descriptions, please refer to the [Favicons package documentation](https://www.npmjs.com/package/favicons).

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -2,3 +2,13 @@ declare module 'virtual:favicons' {
 	const html: string;
 	export default html;
 }
+
+/**
+ * Process-wide registry of in-flight favicon generations, keyed by output
+ * destination and content hash. Stored on `globalThis` so separate plugin
+ * instances in the same Node process share it.
+ */
+// eslint-disable-next-line no-var, vars-on-top
+declare var __vitePluginFaviconsBuildPromises:
+	| Map<string, Promise<void>>
+	| undefined;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,19 @@ export interface Options extends FaviconOptions {
 
 	/** whether to cache the generated favicons (default: false on Production, true on Development) */
 	cache?: boolean;
+
+	/**
+	 * whether to collapse identical favicon generations within a single Node
+	 * process into one run. Useful when the same plugin runs multiple times in
+	 * one `vite build` (e.g. SvelteKit's client and server builds), which would
+	 * otherwise regenerate the same favicons twice.
+	 *
+	 * This is distinct from `cache`: `cache` reuses generated output across
+	 * separate builds via the disk, while `dedupe` shares a single in-flight
+	 * generation between plugin instances in the same process.
+	 * @default true
+	 */
+	dedupe?: boolean;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,19 @@ const virtualModuleId = `virtual:favicons`;
 const resolvedVirtualModuleId = `\0${virtualModuleId}`;
 
 /**
+ * Process-wide registry of in-flight favicon generations, keyed by output
+ * destination and content hash.
+ *
+ * It lives on `globalThis` rather than in module scope so that separate plugin
+ * instances within the same Node process share it even if this module ends up
+ * instantiated more than once (e.g. SvelteKit's client and server builds load
+ * the config independently). Storing the `Promise` — not just a boolean — lets
+ * a later instance `await` an ongoing generation instead of starting its own.
+ * @type {Map<string, Promise<void>>}
+ */
+const buildPromises = (globalThis.__vitePluginFaviconsBuildPromises ??= new Map());
+
+/**
  * Get the parent directory path of a given path.
  * @param {string} p - The path to get the parent directory from.
  * @returns {string} - The parent directory path.
@@ -27,6 +40,7 @@ export function faviconsPlugin(options) {
 	const {
 		imgSrc,
 		cache = !isProduction,
+		dedupe = true,
 		...faviconConfig
 	} = options;
 
@@ -73,61 +87,103 @@ export function faviconsPlugin(options) {
 		async buildStart() {
 			logger.info('build start');
 
-			/** Cache key */
-			const cacheKey = `<!-- ${
-				createHash('md5').update(
-					JSON.stringify(options) + await fs.readFile(imgSrc, 'utf-8'),
-				).digest('hex')
-			} -->`;
+			/* Read the source image as raw bytes. It is hashed as a Buffer rather
+			   than a UTF-8 string because the input is binary, where lossy UTF-8
+			   decoding would weaken the hash. */
+			const img = await fs.readFile(imgSrc);
 
-			/* Skip regeneration if a cache exists */
-			if (fs.existsSync(htmlDest) && cache) {
-				const oldHTML = await fs.readFile(htmlDest, 'utf-8');
-				/* Skip regeneration if the cache key is found at the end of the HTML file */
-				if (oldHTML.endsWith(cacheKey)) {
-					logger.info('Cache Hit');
-					return;
+			/* Content hash over the output destination, the favicon config and the
+			   image bytes. It identifies a unique generation: a different config or
+			   output dir must not be deduped against this one. */
+			const hash = createHash('sha256')
+				.update(JSON.stringify({ faviconAssetsDest, faviconConfig }))
+				.update(img)
+				.digest('hex');
+
+			/** Cache key appended to the generated HTML to detect disk cache hits */
+			const cacheKey = `<!-- ${hash} -->`;
+
+			/**
+			 * Generate the favicons once, honouring the on-disk cache.
+			 * @returns {Promise<void>}
+			 */
+			const generate = async () => {
+				/* Skip regeneration if a cache exists */
+				if (fs.existsSync(htmlDest) && cache) {
+					const oldHTML = await fs.readFile(htmlDest, 'utf-8');
+					/* Skip regeneration if the cache key is found at the end of the HTML file */
+					if (oldHTML.endsWith(cacheKey)) {
+						logger.info('Cache Hit');
+						return;
+					}
 				}
-			}
 
-			/* Delete existing files */
-			if (fs.existsSync(faviconAssetsDest)) {
-				await fs.rm(faviconAssetsDest, { recursive: true });
-			}
+				/* Delete existing files */
+				if (fs.existsSync(faviconAssetsDest)) {
+					await fs.rm(faviconAssetsDest, { recursive: true });
+				}
 
-			/* Delete existing HTML */
-			if (fs.existsSync(htmlDest)) {
-				await fs.rm(htmlDest);
-			}
+				/* Delete existing HTML */
+				if (fs.existsSync(htmlDest)) {
+					await fs.rm(htmlDest);
+				}
 
-			/* Create favicon directory in the static assets */
-			await fs.mkdir(faviconAssetsDest, { recursive: true });
-			await fs.mkdir(getParentDirPath(htmlDest), { recursive: true });
+				/* Create favicon directory in the static assets */
+				await fs.mkdir(faviconAssetsDest, { recursive: true });
+				await fs.mkdir(getParentDirPath(htmlDest), { recursive: true });
 
-			/* Generate favicons */
-			const response = await favicons(imgSrc, faviconConfig);
+				/* Generate favicons */
+				const response = await favicons(imgSrc, faviconConfig);
 
-			await Promise.all([
-				/* Write the generated favicon images */
-				...response.images.map(async image =>
-					fs.writeFile(
-						path.resolve(faviconAssetsDest, image.name),
-						image.contents,
+				await Promise.all([
+					/* Write the generated favicon images */
+					...response.images.map(async image =>
+						fs.writeFile(
+							path.resolve(faviconAssetsDest, image.name),
+							image.contents,
+						),
 					),
-				),
-				/* Write the generated favicon files */
-				...response.files.map(async file =>
-					fs.writeFile(
-						path.resolve(faviconAssetsDest, file.name),
-						file.contents,
+					/* Write the generated favicon files */
+					...response.files.map(async file =>
+						fs.writeFile(
+							path.resolve(faviconAssetsDest, file.name),
+							file.contents,
+						),
 					),
-				),
-				/*
-				Write the generated HTML and append the cache key at the end */
-				fs.writeFile(htmlDest, response.html.join('\n') + cacheKey),
-			]);
+					/*
+					Write the generated HTML and append the cache key at the end */
+					fs.writeFile(htmlDest, response.html.join('\n') + cacheKey),
+				]);
 
-			logger.info(`Favicon generated at ${faviconAssetsDest}`);
+				logger.info(`Favicon generated at ${faviconAssetsDest}`);
+			};
+
+			/* Without dedupe, generate inline every time buildStart runs. */
+			if (!dedupe) {
+				await generate();
+				return;
+			}
+
+			/* Process-level dedupe: if an identical generation is already running
+			   (or finished) in this process, await it instead of regenerating.
+			   This collapses the double generation seen when one `vite build` runs
+			   the plugin for both the client and server builds. */
+			const processKey = `${faviconAssetsDest}:${hash}`;
+			const existing = buildPromises.get(processKey);
+			if (existing != null) {
+				logger.info('Favicon generation already handled in this process');
+				await existing;
+				return;
+			}
+
+			/* Store the promise before awaiting so a concurrent instance can join
+			   the same in-flight generation. */
+			const promise = generate();
+			buildPromises.set(processKey, promise);
+			/* Drop a failed generation from the registry so a later build (e.g. in
+			   watch mode) can retry instead of replaying the cached rejection. */
+			promise.catch(() => buildPromises.delete(processKey));
+			await promise;
 		},
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -168,12 +168,31 @@ export function faviconsPlugin(options) {
 			   (or finished) in this process, await it instead of regenerating.
 			   This collapses the double generation seen when one `vite build` runs
 			   the plugin for both the client and server builds. */
-			const processKey = `${faviconAssetsDest}:${hash}`;
+			const destPrefix = `${faviconAssetsDest}:`;
+			const processKey = `${destPrefix}${hash}`;
+
+			/* Evict stale entries for this destination whose source content has
+			   changed. The newest generation for a destination supersedes older
+			   ones, so the registry holds at most one promise per destination and
+			   does not grow unbounded across watch-mode rebuilds. */
+			for (const key of buildPromises.keys()) {
+				if (key.startsWith(destPrefix) && key !== processKey) {
+					buildPromises.delete(key);
+				}
+			}
+
 			const existing = buildPromises.get(processKey);
 			if (existing != null) {
-				logger.info('Favicon generation already handled in this process');
+				/* Wait for the in-flight or finished generation, then make sure its
+				   output still exists on disk — it may have been removed externally
+				   (e.g. a manual clean during watch mode), in which case we must
+				   regenerate rather than trust the cached result. */
 				await existing;
-				return;
+				if (fs.existsSync(htmlDest)) {
+					logger.info('Favicon generation already handled in this process');
+					return;
+				}
+				buildPromises.delete(processKey);
 			}
 
 			/* Store the promise before awaiting so a concurrent instance can join

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -1,0 +1,116 @@
+import type { Options } from '../src/index.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+/* Mock the heavy `favicons` generator so the tests only assert how often the
+   plugin reaches it, not the real image generation. */
+const faviconsMock = vi.hoisted(() => vi.fn());
+vi.mock('favicons', () => ({ favicons: faviconsMock }));
+
+const { faviconsPlugin } = await import('../src/index.js');
+
+const imgSrc = path.resolve(import.meta.dirname, '../example/static/favicon.png');
+
+let publicDir: string;
+
+/**
+ * Read the process-wide dedupe registry stored on `globalThis`.
+ * @returns the registry map, or undefined if no generation has run yet.
+ */
+function getRegistry(): Map<string, Promise<void>> | undefined {
+	return (globalThis as { __vitePluginFaviconsBuildPromises?: Map<string, Promise<void>> })
+		.__vitePluginFaviconsBuildPromises;
+}
+
+type Hook = (this: unknown, ...args: unknown[]) => unknown;
+
+/**
+ * Extract the callable handler from a Vite/Rollup hook, which may be either a
+ * bare function or an `{ handler }` object form.
+ * @param hook - the plugin hook value.
+ * @returns the underlying handler function.
+ */
+function getHook(hook: unknown): Hook {
+	return (typeof hook === 'function' ? hook : (hook as { handler: Hook }).handler) as Hook;
+}
+
+/**
+ * Create a configured plugin instance pointed at the test's temp `publicDir`.
+ * @param overrides - extra options merged over the defaults.
+ * @returns the resolved Vite plugin.
+ */
+async function makePlugin(overrides: Partial<Options> = {}) {
+	const plugin = faviconsPlugin({ imgSrc, path: '/favicons', ...overrides });
+	await getHook(plugin.configResolved).call(plugin, { publicDir });
+	return plugin;
+}
+
+/**
+ * Invoke a plugin's `buildStart` hook directly.
+ * @param plugin - a plugin returned by {@link makePlugin}.
+ */
+async function runBuildStart(plugin: Awaited<ReturnType<typeof makePlugin>>) {
+	await getHook(plugin.buildStart).call({});
+}
+
+beforeEach(async () => {
+	faviconsMock.mockReset();
+	faviconsMock.mockResolvedValue({
+		images: [],
+		files: [],
+		html: ['<link rel="icon" href="/favicons/favicon.svg">'],
+	});
+	getRegistry()?.clear();
+
+	publicDir = await mkdtemp(path.join(tmpdir(), 'vpf-'));
+	return async () => {
+		await rm(publicDir, { recursive: true, force: true });
+	};
+});
+
+it('dedupes favicon generation across plugin instances in the same process', async () => {
+	const a = await makePlugin();
+	const b = await makePlugin();
+
+	await runBuildStart(a);
+	await runBuildStart(b);
+
+	expect(faviconsMock).toHaveBeenCalledTimes(1);
+});
+
+it('regenerates for every build when dedupe is disabled', async () => {
+	/* Also disable the disk cache, which would otherwise short-circuit the
+	   second build and hide whether dedupe was the cause. */
+	const a = await makePlugin({ dedupe: false, cache: false });
+	const b = await makePlugin({ dedupe: false, cache: false });
+
+	await runBuildStart(a);
+	await runBuildStart(b);
+
+	expect(faviconsMock).toHaveBeenCalledTimes(2);
+});
+
+it('regenerates when the previous output was removed externally', async () => {
+	const a = await makePlugin();
+	await runBuildStart(a);
+	expect(faviconsMock).toHaveBeenCalledTimes(1);
+
+	/* Simulate a manual clean of the output between builds (e.g. in watch mode). */
+	await rm(path.join(publicDir, 'favicons'), { recursive: true, force: true });
+
+	const b = await makePlugin();
+	await runBuildStart(b);
+	expect(faviconsMock).toHaveBeenCalledTimes(2);
+});
+
+it('keeps at most one registry entry per destination across content changes', async () => {
+	/* Two builds for the same destination but different configs produce different
+	   hashes; the newer one should evict the older so the registry stays bounded. */
+	await runBuildStart(await makePlugin({ theme_color: '#000000' }));
+	await runBuildStart(await makePlugin({ theme_color: '#ffffff' }));
+
+	const entries = [...(getRegistry()?.keys() ?? [])].filter(key => key.includes('favicons'));
+	expect(entries).toHaveLength(1);
+});

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -38,11 +38,16 @@ function getHook(hook: unknown): Hook {
 
 /**
  * Create a configured plugin instance pointed at the test's temp `publicDir`.
+ *
+ * `cache` defaults to `false` so these tests isolate process-level dedupe from
+ * the on-disk cache: with the disk cache on (its own default depends on
+ * `NODE_ENV`), a second build would be skipped by a cache hit regardless of
+ * whether dedupe works, hiding any regression.
  * @param overrides - extra options merged over the defaults.
  * @returns the resolved Vite plugin.
  */
 async function makePlugin(overrides: Partial<Options> = {}) {
-	const plugin = faviconsPlugin({ imgSrc, path: '/favicons', ...overrides });
+	const plugin = faviconsPlugin({ imgSrc, path: '/favicons', cache: false, ...overrides });
 	await getHook(plugin.configResolved).call(plugin, { publicDir });
 	return plugin;
 }
@@ -81,10 +86,8 @@ it('dedupes favicon generation across plugin instances in the same process', asy
 });
 
 it('regenerates for every build when dedupe is disabled', async () => {
-	/* Also disable the disk cache, which would otherwise short-circuit the
-	   second build and hide whether dedupe was the cause. */
-	const a = await makePlugin({ dedupe: false, cache: false });
-	const b = await makePlugin({ dedupe: false, cache: false });
+	const a = await makePlugin({ dedupe: false });
+	const b = await makePlugin({ dedupe: false });
 
 	await runBuildStart(a);
 	await runBuildStart(b);


### PR DESCRIPTION
## Summary

Stops the **double favicon generation** that happens when a single `vite build` runs the plugin more than once — e.g. SvelteKit's client and server builds. On a cold build the plugin reached `favicons()` on every `buildStart`, regenerating the exact same favicons twice.

This adds **process-level dedupe**: identical generations (same output destination, favicon config, and source image bytes) share a single in-flight run within one Node process.

## Changes

- **Process-wide registry**: in-flight generation promises are stored in a `globalThis` `Map` keyed by output destination + content hash, so separate plugin instances in the same process join one generation instead of starting their own. Storing the *promise* (not a boolean) lets a later instance `await` an ongoing run.
- **New `dedupe` option** (default `true`), kept distinct from `cache`:
  - `cache` → reuse generated output across separate builds via disk
  - `dedupe` → share a single generation across instances within one process
- **Hashing**: source image is now hashed as a `Buffer` instead of a lossy UTF-8 string, and the hash moves from md5 → sha256.
- **Resilience**: a failed generation is evicted from the registry so watch-mode rebuilds can retry instead of replaying a cached rejection.
- **Docs**: README now documents both `cache` and `dedupe`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test run` all pass
- Example SvelteKit build now logs a single generation:
  ```
  [vite-plugin-favicon] ℹ build start
  [vite-plugin-favicon] ℹ Favicon generated at .../static/favicons
  [vite-plugin-favicon] ℹ build start
  [vite-plugin-favicon] ℹ Favicon generation already handled in this process
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dedupe` option to collapse identical favicon generations within the same Node process (default: enabled).
  * Added `cache` option to control reusing generated favicons from disk across builds.

* **Tests**
  * Added test suite validating deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->