### PR TITLE
ci: publish to npm from CI with provenance on tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,39 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
-
 jobs:
-  release:
+  npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+      - run: pnpm test run
+      - run: pnpm prepack
+      - run: pnpm dlx publint
+
+      - run: pnpm publish --provenance --no-git-checks --access public
+
+  release:
+    needs:
+      - npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:

--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
 		"format": "nr lint --fix",
 		"test": "vitest",
 		"prepack": "dts-buddy",
-		"release": "nr release:pre && bumpp && nr release:npm",
-		"release:pre": "nr typecheck && nr test run && nr prepack && publint",
-		"release:npm": "pnpm publish"
+		"release": "nr release:pre && bumpp",
+		"release:pre": "nr typecheck && nr test run && nr prepack && publint"
 	},
 	"peerDependencies": {
 		"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"


### PR DESCRIPTION
## Describe your changes

Set up automated npm publishing in CI, modelled on [ccusage](https://github.com/ryoppippi/ccusage)'s release flow.

Previously the `release` workflow only ran `changelogithub`, and the actual `npm publish` happened locally via `pnpm release`. Now publishing happens from CI on tag push.

- Add an `npm` job to `.github/workflows/release.yaml` that runs the pre-release gates (`typecheck`, `test`, `prepack`, `publint`) and then `pnpm publish --provenance --no-git-checks --access public`.
  - `permissions.id-token: write` enables **OIDC trusted publishing** + provenance, so no `NPM_TOKEN` secret is needed (npm trusted publisher already configured).
- Gate the `changelogithub` (`release`) job on the `npm` job, so the GitHub release is only created after a successful publish.
- Drop the local `release:npm` script. The local `pnpm release` now just validates, bumps the version, and pushes the tag — CI handles publishing.

### Release flow after this change

1. Run `pnpm release` locally → validates, bumps version, pushes a tag.
2. The tag push triggers the `release` workflow.
3. `npm` job publishes to npm with provenance.
4. `release` job creates the GitHub release via `changelogithub`.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] Did you implement the changes in the correct branch?
- [x] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes? (CI config change, not testable via unit tests)
- [x] Did you update the documentation?
- [ ] Did all CI checks pass? (pending)